### PR TITLE
Set environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 
 # Ignore ruby-version
 /.ruby-version
+
+#Ignore environment variable
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem 'puma'
 gem 'line-bot-api'
 gem 'sinatra'
 
+gem 'dotenv'
+
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
+    dotenv (2.7.5)
     erubi (1.8.0)
     execjs (2.7.0)
     ffi (1.11.1)
@@ -170,6 +171,7 @@ PLATFORMS
 
 DEPENDENCIES
   coffee-rails
+  dotenv
   jbuilder
   jquery-rails
   line-bot-api

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,13 +17,16 @@
 default: &default
   adapter: postgresql
   encoding: unicode
+  host: ENV["DATABASE_HOST"]
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: 5
 
 development:
   <<: *default
-  database: ruby-getting-started_development
+  database: ENV["DATABASE_NAME"]
+  username: ENV["DATABASE_USER_NAME"]
+  password: ENV["DATABASE_USER_PASSWORD"]
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.


### PR DESCRIPTION
## 実装の背景・目的

PCの権限の関係上、ローカル環境にPostgreSQLを入れられなかったためHerokuサーバ上のPostgreSQLを利用しています
DB周りの環境設定をdatabase.ymlに記述したままうっかりpushしてしまったので、データベースを消すことで対応しました
データベース(だけを作り直すことはできなかったのでHerokuアプリケーション)を作り直したので、同じ失敗を繰り返さないためにdotenv-railsを導入して環境変数の設定をすると共に、.gitignoreの設定をしました

## やったこと

- dotenv-railsをGemfileに追加
- dotenv-railsのインストール
- .envファイルにデータベース周りの環境変数を追加
- .envファイルにLINE Messaging APIの環境変数を追加
- .gitignoreファイルに.envを追加
- database.ymlにデータベース接続情報を追加

