### PR TITLE
dotenv-railsの設定周りの問題を解消

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'puma'
 gem 'line-bot-api'
 gem 'sinatra'
 
-gem 'dotenv'
+gem 'dotenv-rails'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,9 @@ GEM
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubi (1.8.0)
     execjs (2.7.0)
     ffi (1.11.1)
@@ -171,7 +174,7 @@ PLATFORMS
 
 DEPENDENCIES
   coffee-rails
-  dotenv
+  dotenv-rails
   jbuilder
   jquery-rails
   line-bot-api

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,16 +17,16 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  host: ENV["DATABASE_HOST"]
+  host: <%= ENV['DATABASE_HOST'] %>
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: 5
 
 development:
   <<: *default
-  database: ENV["DATABASE_NAME"]
-  username: ENV["DATABASE_USER_NAME"]
-  password: ENV["DATABASE_USER_PASSWORD"]
+  database: <%= ENV['DATABASE_NAME'] %>
+  username: <%= ENV['DATABASE_USER_NAME'] %>
+  password: <%= ENV['DATABASE_PASSWORD'] %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140707111715) do
+ActiveRecord::Schema.define(version: 2014_07_07_111715) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
## 実装の背景・目的
dotenv-railsの導入にあたり、あらゆる箇所でタイポしておりエラーを吐きまくったので修正しました

## やったこと
- database.yml内の記法ミスを修正
- Gemfileに記載したgem名が間違っていたので修正
- gemのインストールし直し
- db:migrate実行