### PR TITLE
入力に応じた動物の写真を返す機能の実装

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -29,11 +29,8 @@ class WebhookController < ApplicationController
         when Line::Bot::Event::MessageType::Text
           text = event.message['text'].downcase
           messages = [
-            {
-              type: 'text',
-              text: generate_message(text)
-            },
-            get_line_image_hash(text)
+            generate_line_text_hash(text),
+            generate_line_image_hash(text)
           ]
           client.reply_message(event['replyToken'], messages)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
@@ -48,13 +45,20 @@ class WebhookController < ApplicationController
 
   def generate_message(text)
     case text
-    when "ねこ", "猫", "ネコ", "neko", "NEKO", "cat", "CAT"
+    when "ねこ", "猫", "ネコ", "neko","cat"
       return "にゃんにゃん"
-    when "いぬ", "犬", "イヌ", "inu", "INU", "dog", "DOG"
+    when "いぬ", "犬", "イヌ", "inu", "dog"
       return "わんわん"
     else
       return "もふもふ"
     end
+  end
+
+  def generate_line_text_hash(text)
+    return {
+      type: 'text',
+      text: generate_message(text)
+    }
   end
 
   def call_bing_image_search_api(text)
@@ -73,7 +77,7 @@ class WebhookController < ApplicationController
     return JSON.parse(response.body)
   end
 
-  def get_line_image_hash(text)
+  def generate_line_image_hash(text)
     parsed_json = call_bing_image_search_api(text)
 
     random_result = parsed_json["value"].sample


### PR DESCRIPTION
## 実装の背景・目的

入力されたテキストに応じて動物の癒し画像を返す機能を実装しました
癒されたいです

現段階での目標は以下の通りです

〜目標〜
レベル①
・「猫」(に類似しそうな単語)が入力されたら「にゃんにゃん」というテキストを返す
・「犬」(に類似しそうな単語)が入力されたら「わんわん」というテキストを返す
・それ以外の文字列が入力されたら「もふもふ」というテキストを返す

レベル②
・入力に対して画像を返す

レベル③
・見た目をリッチに
・複数件返す
・ボタンプッシュで鳴き声や動物の説明を表示

## やったこと
レベル②の実装

- Bing Image Search APIを叩く
- APIが返した結果からランダムな１枚の写真を返す
- APIが返したURLがhttpだった場合、httpsに変換
- previewの画像サイズを240*240に揃える
- コードの整理

## キャプチャ

![Screenshot_20200205-161840_LINE](https://user-images.githubusercontent.com/28701995/73819990-0e155600-4834-11ea-8a9c-9bb336f159d8.jpg)

## 補足

- APIからのレスポンスが０件だった場合の処理はこれからします
- レベル①で作った機能はそのまま使っています
- 動物以外の単語を入力しても画像が表示されます(ただし、テキストは「もふもふ」)
