### PR TITLE
APIからのレスポンスに応じて表示を切り替える機能の実装

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -79,17 +79,25 @@ class WebhookController < ApplicationController
 
   def generate_line_image_hash(text)
     parsed_json = call_bing_image_search_api(text)
+    json_values = parsed_json["value"]
 
-    random_result = parsed_json["value"].sample
-    
-    originalContentUrl = random_result["contentUrl"]
-    previewImageUrl = random_result["thumbnailUrl"]
+    if json_values.blank?
+      return {
+        type: 'text',
+        text: "ごめんね…見つからなかったみたい"
+      }
+    else
+      random_result = json_values.sample
+      
+      originalContentUrl = random_result["contentUrl"]
+      previewImageUrl = random_result["thumbnailUrl"]
 
-    return {
-      type: 'image',
-      originalContentUrl: replace_to_https(originalContentUrl),
-      previewImageUrl: replace_to_https(previewImageUrl) + "&c=4&w=240&h=240"
-    }
+      return {
+        type: 'image',
+        originalContentUrl: replace_to_https(originalContentUrl),
+        previewImageUrl: replace_to_https(previewImageUrl) + "&c=4&w=240&h=240"
+      }
+    end
   end
 
   def replace_to_https(url)

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -89,7 +89,7 @@ class WebhookController < ApplicationController
   def generate_line_text_hash_when_image_not_found
     return {
         type: 'text',
-        text: "ごめんね…見つからなかったみたい"
+        text: "ごめんね #{0x100098.chr('UTF-8')} \n 見つからなかったみたい…"
       }
   end
 


### PR DESCRIPTION
## 実装の背景・目的

入力されたテキストに応じて動物の癒し画像を返す機能の修正をしました
具体的にはAPIからレスポンスが返らなかった場合の処理を追加しました

## やったこと
APIからのレスポンスが０件だった場合の処理

- APIからレスポンスが返らなかった場合の処理を追加
- APIからのレスポンスがあるかどうかで返すメッセージを帰る処理
- エラーメッセージに絵文字と改行を付加

## キャプチャ

![DM2v5TISS4OEKR8juiFslg_thumb_1](https://user-images.githubusercontent.com/28701995/73836877-96572380-4853-11ea-88cb-21ccceb94b9d.jpg)

## 補足

- LINEの絵文字を送るのが大変難しかったです
