### PR TITLE
入力テキストに応じて複数画像を返す機能の実装

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -28,7 +28,9 @@ class WebhookController < ApplicationController
         case event.type
         when Line::Bot::Event::MessageType::Text
           input_text = event.message['text'].downcase
-          client.reply_message(event['replyToken'], generate_line_massage_array(input_text))
+          responce = client.reply_message(event['replyToken'], generate_line_massage_array(input_text))
+          p responce.message
+          p JSON.parse(responce.body)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           response = client.get_message_content(event.message['id'])
           tf = Tempfile.open("content")
@@ -39,8 +41,8 @@ class WebhookController < ApplicationController
     head :ok
   end
 
-  def generate_message(text)
-    case text
+  def generate_message(input_text)
+    case input_text
     when "ねこ", "猫", "ネコ", "neko","cat"
       return "にゃんにゃん"
     when "いぬ", "犬", "イヌ", "inu", "dog"
@@ -50,18 +52,18 @@ class WebhookController < ApplicationController
     end
   end
 
-  def generate_line_text_hash(text)
+  def generate_line_text_hash(input_text)
     return {
       type: 'text',
-      text: generate_message(text)
+      text: generate_message(input_text)
     }
   end
 
-  def call_bing_image_search_api(text)
+  def call_bing_image_search_api(input_text)
     uri  = "https://api.cognitive.microsoft.com"
     path = "/bing/v7.0/images/search"
     
-    uri = URI("#{uri}#{path}?q=#{URI.escape(text)}")
+    uri = URI("#{uri}#{path}?q=#{URI.escape(input_text)}")
     
     request = Net::HTTP::Get.new(uri)
     request['Ocp-Apim-Subscription-Key'] = ENV["BING_IMAGE_API_KEY"]
@@ -76,33 +78,64 @@ class WebhookController < ApplicationController
   def generate_line_image_hash(json)
     random_result = json.sample
     
-    originalContentUrl = random_result["contentUrl"]
-    previewImageUrl = random_result["thumbnailUrl"]
+    original_content_url = random_result["contentUrl"]
+    preview_image_url = random_result["thumbnailUrl"]
 
     return {
       type: 'image',
-      originalContentUrl: replace_to_https(originalContentUrl),
-      previewImageUrl: replace_to_https(previewImageUrl) + "&c=4&w=240&h=240"
+      originalContentUrl: replace_to_https(original_content_url),
+      previewImageUrl: replace_to_https(preview_image_url) + "&c=4&w=240&h=240"
     }
   end
 
-  def generate_line_text_hash_when_image_not_found
+  def generate_line_text_hash_when_image_not_found(input_text)
     return {
         type: 'text',
-        text: "ごめんね #{0x100098.chr('UTF-8')} \n 見つからなかったみたい…"
+        text: "ごめんね #{0x100098.chr('UTF-8')} \n#{input_text}は見つからなかったみたい… \nちがうどうぶつの名前を入れてみて#{0x10005C.chr('UTF-8')}"
       }
   end
 
-  def generate_line_massage_array(text)
-    json_value = call_bing_image_search_api(text)["value"]
+  def generate_line_massage_array(input_text)
+    json_value = call_bing_image_search_api(input_text)["value"]
     if json_value.blank?
-      return generate_line_text_hash_when_image_not_found
+      return generate_line_text_hash_when_image_not_found(input_text)
     else
-      return [generate_line_text_hash(text), generate_line_image_hash(json_value)]
+      return generate_line_image_carousel_hash(input_text, json_value.sample(10))
     end
   end
 
   def replace_to_https(url)
     return url.sub(/http:/, "https:")
+  end
+
+  def generate_line_image_carousel_columns_hash(json, input_text)
+    return {
+      imageUrl: replace_to_https(json["thumbnailUrl"]) + "&c=4&w=240&h=240",
+      action: {
+        type: "uri",
+        label: generate_message(input_text),
+        uri: json["hostPageUrl"]
+      }
+    }
+  end
+
+  def generate_line_image_carousel_columns_array(json, input_text)
+    image_carousel_columns = Array.new
+    for value in json
+      image_carousel_columns.push(generate_line_image_carousel_columns_hash(value, input_text))
+    end
+    puts image_carousel_columns
+    return image_carousel_columns
+  end
+
+  def generate_line_image_carousel_hash(input_text, json)
+    return {
+      type: 'template',
+      altText: "#{input_text}の画像",
+      template: {
+        type: "image_carousel",
+        columns: generate_line_image_carousel_columns_array(json, input_text)
+      }
+    }
   end
 end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -95,10 +95,18 @@ class WebhookController < ApplicationController
       }
   end
 
+  def generate_line_sticker_hash(packageId, stickerId)
+    return{
+      type: 'sticker',
+      packageId: packageId,
+      stickerId: stickerId
+    }
+  end
+
   def generate_line_massage_array(input_text)
     json_value = call_bing_image_search_api(input_text)["value"]
     if json_value.blank?
-      return generate_line_text_hash_when_image_not_found(input_text)
+      return [generate_line_text_hash_when_image_not_found(input_text), generate_line_sticker_hash(11539, 52114110)]
     else
       return generate_line_image_carousel_hash(input_text, json_value.sample(10))
     end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -30,8 +30,6 @@ class WebhookController < ApplicationController
         when Line::Bot::Event::MessageType::Text
           input_text = event.message['text'].downcase
           responce = client.reply_message(event['replyToken'], generate_line_massage_array(input_text))
-          p responce.message
-          p JSON.parse(responce.body)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           response = client.get_message_content(event.message['id'])
           tf = Tempfile.open("content")
@@ -143,7 +141,6 @@ class WebhookController < ApplicationController
     for value in json
       image_carousel_columns.push(generate_line_image_carousel_columns_hash(value, input_text))
     end
-    puts image_carousel_columns
     return image_carousel_columns
   end
 

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -137,9 +137,8 @@ class WebhookController < ApplicationController
 
   # LINEのAPIの画像カルーセルテンプレートに渡す画像情報(カラム)の配列をBingのAPIから返されたJSONに基づいて生成
   def generate_line_image_carousel_columns_array(json, input_text)
-    image_carousel_columns = Array.new
-    for value in json
-      image_carousel_columns.push(generate_line_image_carousel_columns_hash(value, input_text))
+    image_carousel_columns  = json.map do |value|
+      generate_line_image_carousel_columns_hash(value, input_text)
     end
     return image_carousel_columns
   end


### PR DESCRIPTION
## 実装の背景・目的

入力されたテキストに応じた動物の癒し画像を送信するBotを作りたいです

現段階での目標と進捗は以下の通りです

〜目標〜
レベル①→済
・「猫」(に類似しそうな単語)が入力されたら「にゃんにゃん」というテキストを返す
・「犬」(に類似しそうな単語)が入力されたら「わんわん」というテキストを返す
・それ以外の文字列が入力されたら「もふもふ」というテキストを返す

レベル②→済
・入力に対して画像を返す

レベル③
・見た目をリッチに
・複数件返す
・ボタンプッシュで鳴き声や動物の説明を表示

## やったこと

レベル③の上2つの機能を実装

- 表示する画像の件数を増やす
- LINEの画像カルーセルテンプレートを採用
https://developers.line.biz/ja/reference/messaging-api/#image-carousel
- 画像タップで画像の参照元URLに飛ぶ仕様
- 画像が取得できなかった場合のエラーメッセージの変更
- 画像が取得できなかった場合のエラーメッセージにスタンプを追加

## キャプチャ

- 正常動作
![a6KLgr2hRea13m5iGp2WXQ_thumb_2](https://user-images.githubusercontent.com/28701995/73915286-5d27bd80-48fe-11ea-9f1a-710cdfa14fa2.jpg)

- 画像が見つからない場合
![u9ejNz+qR0aQvgYrcqz+Gw_thumb_4](https://user-images.githubusercontent.com/28701995/73915467-c27bae80-48fe-11ea-9f31-03c5954b95a0.jpg)

- キティちゃんもラーメン二郎も もふもふ
![XrOWpiQATuaTM5PKAEhBNA_thumb_3](https://user-images.githubusercontent.com/28701995/73915354-88121180-48fe-11ea-8e95-b3c0e6cdcf1e.jpg)

![kAgHHTCeSCeD5pp9331g5g_thumb_6](https://user-images.githubusercontent.com/28701995/73915419-aaa42a80-48fe-11ea-81d1-c295faab67f2.jpg)


## 補足

- メソッドの命名や切り分けに自信が全くないのでアドバイスいただきたいです
- 相変わらず動物かどうかの判定ロジックは入っていません
