### PR TITLE
テキスト以外の入力の時の対処

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -29,10 +29,12 @@ class WebhookController < ApplicationController
         when Line::Bot::Event::MessageType::Text
           input_text = event.message['text'].downcase
           client.reply_message(event['replyToken'], generate_line_massage_array(input_text))
-        when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
-          response = client.get_message_content(event.message['id'])
-          tf = Tempfile.open("content")
-          tf.write(response.body)
+        else
+          message = {
+            type: 'text',
+            text: "テキストメッセージにしかお返事できないんだ #{0x100018.chr('UTF-8')} \nごめんね #{0x100029.chr('UTF-8')}#{0x100029.chr('UTF-8')} \nテキストでどうぶつの名前を入れてみて#{0x10005F.chr('UTF-8')}"
+          }
+          client.reply_message(event['replyToken'], message)
         end
       end
     }


### PR DESCRIPTION
## 実装の背景・目的
テキスト以外のメッセージを受け取った時に謎のエラーを返していたので、テキストで返信するように変更しました

## やったこと
- テキスト以外の入力に対して謝罪する